### PR TITLE
Updated minimalmodbus.read_string arg

### DIFF
--- a/solarshed/controllers/renogy_rover.py
+++ b/solarshed/controllers/renogy_rover.py
@@ -38,7 +38,7 @@ class RenogyRover(minimalmodbus.Instrument):
         """
         Read the controller's model information
         """
-        return self.read_string(12, numberOfRegisters=8)
+        return self.read_string(12, number_of_registers=8)
 
     def system_voltage_current(self):
         """


### PR DESCRIPTION
For `minimalmodbus.read_string()`, the `numberOfDecimals` was changed to `number_of_decimals`.

This change took effect as of MinimalModbus 1.0, refer to https://minimalmodbus.readthedocs.io/en/stable/apiminimalmodbus.html#minimalmodbus.Instrument.read_register

Before fixing, the following error was encountered:
```
$ python3 renogy_rover.py 
Traceback (most recent call last):
  File "renogy_rover.py", line 185, in <module>
    print('Model: ', rover.model())
  File "renogy_rover.py", line 41, in model
    return self.read_string(12, numberOfRegisters=8)
TypeError: read_string() got an unexpected keyword argument 'numberOfRegisters'
```