### PR TITLE
Removed minimalmodbus constants, added default constructor arguments

### DIFF
--- a/solarshed/controllers/renogy_rover.py
+++ b/solarshed/controllers/renogy_rover.py
@@ -38,7 +38,7 @@ class RenogyRover(minimalmodbus.Instrument):
         """
         Read the controller's model information
         """
-        return self.read_string(12, numberOfRegisters=8)
+        return self.read_string(12, number_of_registers=8)
 
     def system_voltage_current(self):
         """

--- a/solarshed/controllers/renogy_rover.py
+++ b/solarshed/controllers/renogy_rover.py
@@ -4,10 +4,6 @@ Driver for the Renogy Rover Solar Controller using the Modbus RTU protocol
 
 import minimalmodbus
 
-minimalmodbus.BAUDRATE = 9600
-minimalmodbus.TIMEOUT = 0.5
-
-
 BATTERY_TYPE = {
     1: 'open',
     2: 'sealed',
@@ -31,14 +27,16 @@ class RenogyRover(minimalmodbus.Instrument):
     Communicates using the Modbus RTU protocol (via provided USB<->RS232 cable)
     """
 
-    def __init__(self, portname, slaveaddress):
+    def __init__(self, portname, slaveaddress, baudrate=9600, timeout=0.5):
         minimalmodbus.Instrument.__init__(self, portname, slaveaddress)
+        self.serial.baudrate = baudrate
+        self.serial.timeout = timeout
 
     def model(self):
         """
         Read the controller's model information
         """
-        return self.read_string(12, number_of_registers=8)
+        return self.read_string(12, numberOfRegisters=8)
 
     def system_voltage_current(self):
         """


### PR DESCRIPTION
Removed unsupported module-level constants for `BAUDRATE` and `TIMEOUT`, instead using default arguments in the constructor to initialize the values for use on the pyserial object.

This change took effect as of MinimalModbus 1.0 which the RenogyRover class inherits, refer to https://minimalmodbus.readthedocs.io/en/stable/usage.html#default-values

Before fixing, the following error was encountered:
```
$ python3 renogy_rover.py 
Traceback (most recent call last):
  File "renogy_rover.py", line 185, in <module>
    print('Model: ', rover.model())
  File "renogy_rover.py", line 41, in model
    return self.read_string(12, number_of_registers=8)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/minimalmodbus.py", line 751, in read_string
    return self._generic_command(
  File "/home/ubuntu/.local/lib/python3.8/site-packages/minimalmodbus.py", line 1170, in _generic_command
    payload_from_slave = self._perform_command(functioncode, payload_to_slave)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/minimalmodbus.py", line 1240, in _perform_command
    response = self._communicate(request, number_of_bytes_to_read)
  File "/home/ubuntu/.local/lib/python3.8/site-packages/minimalmodbus.py", line 1406, in _communicate
    raise NoResponseError("No communication with the instrument (no answer)")
minimalmodbus.NoResponseError: No communication with the instrument (no answer)
```
